### PR TITLE
Add support for environments where WP files are not in the web root

### DIFF
--- a/lti.php
+++ b/lti.php
@@ -187,7 +187,7 @@ class LTI {
     global $wpdb;
     echo '<p>';
     _e( 'Your API endpoint can be accessed via the following URL. Replace BLOGID with the site id of the site the user should be redirected to.' );
-    echo '<div>' . get_site_url(1) . '/api/lti/BLOGID</div>';
+    echo '<div>' . get_home_url(1) . '/api/lti/BLOGID</div>';
     echo '</p>';
   }
 

--- a/single-lti_consumer.php
+++ b/single-lti_consumer.php
@@ -22,7 +22,7 @@ get_header(); ?>
           }
 
           global $wpdb;
-          $endpoint = get_site_url(1) . '/api/lti/BLOGID';
+          $endpoint = get_home_url(1) . '/api/lti/BLOGID';
           echo '<div><label for="lti_consumer_endpoint">';
           _e( 'Endpoint' );
           echo ': </label>';


### PR DESCRIPTION
In conventional WordPress configurations, the values of `get_site_url()` and `get_home_url()` are equal. However, some configurations, like [roots/bedrock](https://github.com/roots/bedrock), keep the WordPress core files in a subdirectory of the web root, meaning that `get_site_url()` will return `https://domain.com/wp` while `get_home_url()` will return `https://domain.com`. This PR substitutes `get_home_url()` for `get_site_url()` for broader support of different WordPress configurations.